### PR TITLE
fixed typo in var name gitea_configuration_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Here are all our ansible roles for installing git server.
 ## Using this Collection
 You can install the collection using ansible-galaxy by running:
 ```bash
-ansible-galaxy collection install l3d.git:1.0.8
+ansible-galaxy collection install l3d.git:1.0.9
 ```
 
 Remember you can to Upgrade to the latest version of the l3d.git collection using the ``--upgrade`` parameter:
@@ -43,7 +43,7 @@ You can also list a collection in ``requirements.yml``:
 ---
 collections:
   - name: l3d.git
-    version: ">=1.0.8"
+    version: ">=1.0.9"
 ```
 
 ## Include roles in your playbook

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: l3d
 name: git
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.8
+version: 1.0.9
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
```
gitea_configuraion_path --> gitea_configuration_path
```
See https://github.com/roles-ansible/ansible_role_gitea/pull/115 and https://github.com/roles-ansible/ansible_role_gitea/releases/tag/v3.2.9